### PR TITLE
Daily supporter churn email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# supporter-metrics-job
+
+This job runs regularly to pull data from presto and drop it in an email to the team.

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ses" % "1.11.180",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.0.0",
-  "org.apache.logging.log4j" % "log4j-api" % "2.8.2",
-  "org.apache.logging.log4j" % "log4j-core" % "2.8.2" % Runtime,
   "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0",
   "com.typesafe" % "config" % "1.3.1"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ses" % "1.11.180",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.0.0",
+  "org.apache.logging.log4j" % "log4j-api" % "2.8.2",
+  "org.apache.logging.log4j" % "log4j-core" % "2.8.2" % Runtime,
   "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0",
   "com.typesafe" % "config" % "1.3.1"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ses" % "1.11.180",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.0.0",
-  "com.typesafe" % "config" % "1.3.1"
+  "com.facebook.presto" % "presto-jdbc" % "0.182"
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,34 @@
+name := "supporter-metrics-job"
+
+organization := "com.gu"
+
+description:= "This job runs regularly to pull data from presto and drop it in an email to the team."
+
+version := "1.0"
+
+scalaVersion := "2.12.2"
+
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-target:jvm-1.8",
+  "-Ywarn-dead-code"
+)
+
+libraryDependencies ++= Seq(
+  "com.amazonaws" % "aws-java-sdk-ses" % "1.11.180",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.0.0",
+  "org.apache.logging.log4j" % "log4j-api" % "2.8.2",
+  "org.apache.logging.log4j" % "log4j-core" % "2.8.2" % Runtime,
+  "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0",
+  "com.typesafe" % "config" % "1.3.1"
+)
+
+enablePlugins(RiffRaffArtifact)
+
+assemblyJarName := s"${name.value}.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffArtifactResources += (file("cfn.yaml"), s"${name.value}-cfn/cfn.yaml")

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,7 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-ses" % "1.11.180",
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-  "org.apache.logging.log4j" % "log4j-api" % "2.8.2",
-  "org.apache.logging.log4j" % "log4j-core" % "2.8.2" % Runtime,
-  "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.0.0",
   "com.typesafe" % "config" % "1.3.1"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,3 +29,10 @@ riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("cfn.yaml"), s"${name.value}-cfn/cfn.yaml")
+
+import sbtassembly.Log4j2MergeStrategy
+
+assemblyMergeStrategy in assembly := {
+  case PathList(ps@_*) if ps.last == "Log4j2Plugins.dat" => Log4j2MergeStrategy.plugincache
+  case x => MergeStrategy.defaultMergeStrategy(x)
+}

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -28,6 +28,14 @@ Parameters:
     Description: email address to send emails to
     Type: String
     Default: john.duffell@guardian.co.uk
+  PrestoUrl:
+    Description: presto db jdbc url
+    Type: String
+    Default: jdbc:presto://...
+  EmailLine:
+    Description: email address to send emails to
+    Type: String
+    Default: See https://drive.google.com (TODO) for more details
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -79,6 +87,8 @@ Resources:
           App: !Ref App
           EmailFrom: !Ref EmailFrom
           EmailTo: !Ref EmailTo
+          PrestoUrl: !Ref PrestoUrl
+          EmailLine: !Ref EmailLine
       Description: This job runs regularly to pull data from presto and drop it in an email to the team.
       Handler: com.gu.supportermetricsjob.Lambda::handler
       MemorySize: 128

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -57,6 +57,13 @@ Resources:
               Action:
                 - lambda:InvokeFunction
               Resource: "*"
+        - PolicyName: email
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ses:SendEmail
+              Resource: "*"
   Lambda:
     Type: AWS::Lambda::Function
     Properties:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -1,0 +1,97 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: This job runs regularly to pull data from presto and drop it in an email to the team.
+Parameters:
+  Stack:
+    Description: Stack name
+    Type: String
+    Default: supporter-metrics-job
+  App:
+    Description: Application name
+    Type: String
+    Default: supporter-metrics-job
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - CODE
+      - PROD
+    Default: CODE
+  DeployBucket:
+    Description: Bucket where RiffRaff uploads artifacts on deploy
+    Type: String
+    Default: supporter-metrics-job-dist
+  EmailFrom:
+    Description: from address for emails
+    Type: String
+    Default: john.duffell@guardian.co.uk
+  EmailTo:
+    Description: email address to send emails to
+    Type: String
+    Default: john.duffell@guardian.co.uk
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: logs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+              Resource: arn:aws:logs:*:*:*
+        - PolicyName: lambda
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - lambda:InvokeFunction
+              Resource: "*"
+  Lambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${App}-${Stage}
+      Code:
+        S3Bucket:
+          Ref: DeployBucket
+        S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          Stack: !Ref Stack
+          App: !Ref App
+          EmailFrom: !Ref EmailFrom
+          EmailTo: !Ref EmailTo
+      Description: This job runs regularly to pull data from presto and drop it in an email to the team.
+      Handler: com.gu.supportermetricsjob.Lambda::handler
+      MemorySize: 128
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 60
+
+  DailyEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Event sent to process the previous day of data
+      ScheduleExpression: cron(14 3 * * ? *)
+      Targets:
+        - Id: Lambda
+          Arn: !GetAtt Lambda.Arn
+
+  DailyEventLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt Lambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DailyEvent.Arn

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
+
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,12 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.7.0")
+
+resolvers += Resolver.url(
+  "idio",
+  url("http://dl.bintray.com/idio/sbt-plugins")
+)(Resolver.ivyStylePatterns)
+
+addSbtPlugin("org.idio" % "sbt-assembly-log4j2" % "0.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.8")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.7.0")
-
 resolvers += Resolver.url(
   "idio",
   url("http://dl.bintray.com/idio/sbt-plugins")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,19 @@
+stacks: [supporter-metrics-job]
+regions: [eu-west-1]
+
+deployments:
+  supporter-metrics-job:
+    type: aws-lambda
+    parameters:
+      bucket: supporter-metrics-job-dist
+      functionNames: [supporter-metrics-job-]
+      fileName: supporter-metrics-job.jar
+      prefixStack: false
+    dependencies: [supporter-metrics-job-cfn]
+  supporter-metrics-job-cfn:
+    type: cloud-formation
+    app: supporter-metrics-job
+    parameters:
+      prependStackToCloudFormationStackName: false
+      cloudFormationStackName: supporter-metrics-job
+      templatePath: cfn.yaml

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,4 +1,4 @@
-stacks: [supporter-metrics-job]
+stacks: [memb-supporter-metrics-job]
 regions: [eu-west-1]
 
 deployments:

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -12,16 +12,3 @@
         </Root>
     </Loggers>
 </Configuration>
-<!--
-log = .
-log4j.rootLogger = INFO, LAMBDA, A1
-
-# Define the LAMBDA Appender
-log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
-log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
-log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n
-
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-5p %c %x - %m%n
--->

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" packages="com.amazonaws.services.lambda.runtime.log4j2">
+    <Appenders>
+        <Lambda name="LambdaAppender">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %X{AWSRequestId} %-5p %c{1}:%L - %m%n"/>
+        </Lambda>
+    </Appenders>
+
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="LambdaAppender" />
+        </Root>
+    </Loggers>
+</Configuration>
+<!--
+log = .
+log4j.rootLogger = INFO, LAMBDA, A1
+
+# Define the LAMBDA Appender
+log4j.appender.LAMBDA=com.amazonaws.services.lambda.runtime.log4j.LambdaAppender
+log4j.appender.LAMBDA.layout=org.apache.log4j.PatternLayout
+log4j.appender.LAMBDA.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n
+
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-5p %c %x - %m%n
+-->

--- a/src/main/scala/com/gu/supportermetricsjob/Emailer.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/Emailer.scala
@@ -1,0 +1,36 @@
+package com.gu.supportermetricsjob
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailService, AmazonSimpleEmailServiceAsyncClientBuilder }
+import com.amazonaws.services.simpleemail.model._
+
+import scala.util.Try
+
+object Emailer extends Logging {
+
+  def makeSes()(implicit credentials: AWSCredentialsProvider): AmazonSimpleEmailService = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
+    .withCredentials(credentials)
+    .withRegion(Regions.EU_WEST_1)
+    .build()
+
+  case class Email(subject: String, body: String, from: String, to: String)
+
+  def sendEmail(email: Email)(implicit ses: AmazonSimpleEmailService) = {
+    logger.info(s"Sending email ${email.subject}")
+
+    val body = new Body(new Content(email.body.replaceAll("<[^>]*>", "")))
+    body.setHtml(new Content(email.body))
+    Try {
+      val request = new SendEmailRequest()
+        .withDestination(new Destination().withToAddresses(email.to))
+        .withSource(email.from)
+        .withMessage(new Message()
+          .withSubject(new Content(email.subject))
+          .withBody(body))
+
+      ses.sendEmail(request)
+    }
+  }
+
+}

--- a/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
@@ -1,0 +1,88 @@
+package com.gu.supportermetricsjob
+
+import com.amazonaws.auth._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.simpleemail.model._
+import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailService, AmazonSimpleEmailServiceAsyncClientBuilder }
+import org.apache.logging.log4j.scala.Logging
+
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * This is compatible with aws' lambda JSON to POJO conversion.
+ * You can test your lambda by sending it the following payload:
+ * {"name": "Bob"}
+ */
+class LambdaInput() {
+  var name: String = _
+  def getName(): String = name
+  def setName(theName: String): Unit = name = theName
+}
+
+case class Env(app: String, stack: String, stage: String, emailTo: String, emailFrom: String)
+
+object Env {
+  def apply(): Env = Env(
+    Option(System.getenv("App")).getOrElse("DEV"),
+    Option(System.getenv("Stack")).getOrElse("DEV"),
+    Option(System.getenv("Stage")).getOrElse("DEV"),
+    Option(System.getenv("EmailTo")).get,
+    Option(System.getenv("EmailFrom")).get)
+}
+
+object Lambda extends Logging {
+
+  val credentials = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("membership"),
+    DefaultAWSCredentialsProviderChain.getInstance())
+
+  val ses: AmazonSimpleEmailService = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
+    .withCredentials(credentials)
+    .withRegion(Regions.EU_WEST_1)
+    .build()
+
+  /*
+   * This is your lambda entry point
+   */
+  def handler(lambdaInput: LambdaInput, context: Context): Unit = {
+    implicit val env = Env()
+    logger.info(s"Starting $env")
+    logger.info(process)
+  }
+
+  def sendEmail(subject: String)(implicit env: Env) = {
+    logger.info(s"Sending email $subject")
+
+    Try {
+      val request = new SendEmailRequest()
+        .withDestination(new Destination().withToAddresses(env.emailTo))
+        .withSource(env.emailFrom)
+        .withMessage(new Message()
+          .withSubject(new Content(subject))
+          .withBody(new Body(new Content("john test email body"))))
+
+      ses.sendEmail(request)
+    }
+  }
+
+  /*
+   * I recommend to put your logic outside of the handler
+   */
+  def process(implicit env: Env): String = {
+    sendEmail("john test email") match {
+      case Failure(e) =>
+        logger.error("failed to send email", e)
+        "failed to send email"
+      case Success(result) => s"successfully emailed: ${result}"
+    }
+  }
+}
+
+object TestIt extends Logging {
+  def main(args: Array[String]): Unit = {
+    logger.info("running in test mode")
+    println(Lambda.process(Env(app = "dev", stack = "dev", stage = "dev", emailTo = "john.duffell@guardian.co.uk", emailFrom = "membership.dev@theguardian.com")))
+  }
+}

--- a/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
@@ -14,8 +14,8 @@ object Lambda extends Logging {
   }
 
   def env(): Config = Config(
-    Option(System.getenv("App")).getOrElse("DEV"),
-    Option(System.getenv("Stack")).getOrElse("DEV"),
+    Option(System.getenv("App")).getOrElse("supporter-metrics-job"),
+    Option(System.getenv("Stack")).getOrElse("memb-supporter-metrics-job"),
     Option(System.getenv("Stage")).getOrElse("DEV"),
     Option(System.getenv("EmailTo")).get,
     Option(System.getenv("EmailFrom")).get,

--- a/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
@@ -1,36 +1,8 @@
 package com.gu.supportermetricsjob
 
-import com.amazonaws.auth._
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.regions.Regions
 import com.amazonaws.services.lambda.runtime.Context
-import com.amazonaws.services.simpleemail.model._
-import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailService, AmazonSimpleEmailServiceAsyncClientBuilder }
+import com.gu.supportermetricsjob.SendChurnEmailsJob.Config
 import org.apache.logging.log4j.{ LogManager, Logger }
-
-import scala.util.{ Failure, Success, Try }
-
-/**
- * This is compatible with aws' lambda JSON to POJO conversion.
- * You can test your lambda by sending it the following payload:
- * {"name": "Bob"}
- */
-class LambdaInput() {
-  var name: String = _
-  def getName(): String = name
-  def setName(theName: String): Unit = name = theName
-}
-
-case class Env(app: String, stack: String, stage: String, emailTo: String, emailFrom: String)
-
-object Env {
-  def apply(): Env = Env(
-    Option(System.getenv("App")).getOrElse("DEV"),
-    Option(System.getenv("Stack")).getOrElse("DEV"),
-    Option(System.getenv("Stage")).getOrElse("DEV"),
-    Option(System.getenv("EmailTo")).get,
-    Option(System.getenv("EmailFrom")).get)
-}
 
 trait Logging {
   protected val logger: Logger = LogManager.getLogger(getClass)
@@ -38,55 +10,26 @@ trait Logging {
 
 object Lambda extends Logging {
 
-  val credentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("membership"),
-    DefaultAWSCredentialsProviderChain.getInstance())
+  class LambdaInput() {
+  }
 
-  val ses: AmazonSimpleEmailService = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
-    .withCredentials(credentials)
-    .withRegion(Regions.EU_WEST_1)
-    .build()
+  def env(): Config = Config(
+    Option(System.getenv("App")).getOrElse("DEV"),
+    Option(System.getenv("Stack")).getOrElse("DEV"),
+    Option(System.getenv("Stage")).getOrElse("DEV"),
+    Option(System.getenv("EmailTo")).get,
+    Option(System.getenv("EmailFrom")).get,
+    Option(System.getenv("PrestoUrl")).get,
+    Option(System.getenv("EmailLine")).get)
 
   /*
    * This is your lambda entry point
    */
   def handler(lambdaInput: LambdaInput, context: Context): Unit = {
-    implicit val env = Env()
-    logger.info(s"Starting $env")
-    logger.info(process)
+    val environment = env()
+    logger.info(s"Starting $environment")
+
+    logger.info(SendChurnEmailsJob.run(env))
   }
 
-  def sendEmail(subject: String)(implicit env: Env) = {
-    logger.info(s"Sending email $subject")
-
-    Try {
-      val request = new SendEmailRequest()
-        .withDestination(new Destination().withToAddresses(env.emailTo))
-        .withSource(env.emailFrom)
-        .withMessage(new Message()
-          .withSubject(new Content(subject))
-          .withBody(new Body(new Content("john test email body"))))
-
-      ses.sendEmail(request)
-    }
-  }
-
-  /*
-   * I recommend to put your logic outside of the handler
-   */
-  def process(implicit env: Env): String = {
-    sendEmail("john test email") match {
-      case Failure(e) =>
-        logger.error("failed to send email", e)
-        "failed to send email"
-      case Success(result) => s"successfully emailed: ${result}"
-    }
-  }
-}
-
-object TestIt extends Logging {
-  def main(args: Array[String]): Unit = {
-    logger.info("running in test mode")
-    println(Lambda.process(Env(app = "dev", stack = "dev", stage = "dev", emailTo = "john.duffell@guardian.co.uk", emailFrom = "membership.dev@theguardian.com")))
-  }
 }

--- a/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/Lambda.scala
@@ -6,7 +6,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.simpleemail.model._
 import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailService, AmazonSimpleEmailServiceAsyncClientBuilder }
-import org.apache.logging.log4j.scala.Logging
+import org.apache.logging.log4j.{ LogManager, Logger }
 
 import scala.util.{ Failure, Success, Try }
 
@@ -30,6 +30,10 @@ object Env {
     Option(System.getenv("Stage")).getOrElse("DEV"),
     Option(System.getenv("EmailTo")).get,
     Option(System.getenv("EmailFrom")).get)
+}
+
+trait Logging {
+  protected val logger: Logger = LogManager.getLogger(getClass)
 }
 
 object Lambda extends Logging {

--- a/src/main/scala/com/gu/supportermetricsjob/PrestoQuery.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/PrestoQuery.scala
@@ -1,0 +1,63 @@
+package com.gu.supportermetricsjob
+
+import java.sql.{ Connection, ResultSet }
+
+import com.gu.supportermetricsjob.Churn.{ ChurnRequest, ChurnResults }
+import org.joda.time._
+
+import scala.util.Try
+
+object PrestoQuery {
+
+  def results[T](resultSet: ResultSet)(f: ResultSet => T) = {
+    new Iterator[T] {
+      def hasNext = resultSet.next()
+      def next() = f(resultSet)
+    }
+  }
+
+  def baseQueryString(statusDate: LocalDate, date: LocalDate) = {
+    val statusDateString = s"date '${statusDate.toString("yyyy-MM-dd")}'"
+    val dateString = s"date '${date.toString("yyyy-MM-dd")}'"
+    s"""
+         select count(1) as base
+         from subscriptions
+         where status_date = $statusDateString
+         and (cancelled_at > $dateString or cancelled_at is null)
+         and signup_date <= $dateString
+         and product_name = 'Supporter'
+      """
+  }
+
+  def churnQueryString(statusDate: LocalDate, endDate: LocalDate, startDate: LocalDate) = {
+    val statusDateString = s"date '${statusDate.toString("yyyy-MM-dd")}'"
+    val endDateString = s"date '${endDate.toString("yyyy-MM-dd")}'"
+    val startDateString = s"date '${startDate.toString("yyyy-MM-dd")}'"
+    s"""
+         select count(1) as churn
+       from subscriptions
+       where status_date = $statusDateString
+       and cancelled_at > $startDateString
+       and cancelled_at < $endDateString
+       and product_name = 'Supporter'
+      """
+  }
+
+  def churnQueries(request: ChurnRequest)(implicit conn: Connection): Try[ChurnResults] = Try {
+    val stmt = conn.createStatement
+
+    val startDate = request.endDate.minus(request.period)
+    val baseStart = results(stmt.executeQuery(baseQueryString(request.statusDate, startDate)))(x => x.getInt("base")).toList.head // todo nice error if !=1 item
+    val baseEnd = results(stmt.executeQuery(baseQueryString(request.statusDate, request.endDate)))(x => x.getInt("base")).toList.head // todo nice error if !=1 item
+    val absoluteChurn = results(stmt.executeQuery(churnQueryString(request.statusDate, request.endDate, startDate)))(x => x.getInt("churn")).toList.head // todo nice error if !=1 item
+
+    val periodsInYear: Double = {
+      val daysInPeriod = Days.daysBetween(startDate, request.endDate).getDays
+      val oneYearAgo = request.endDate.minus(Years.ONE)
+      val daysInYear = Days.daysBetween(oneYearAgo, request.endDate).getDays
+      daysInYear.toDouble / daysInPeriod
+    }
+    ChurnResults(baseStart, baseEnd, absoluteChurn, periodsInYear)
+  }
+
+}

--- a/src/main/scala/com/gu/supportermetricsjob/SendChurnEmailsJob.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/SendChurnEmailsJob.scala
@@ -1,0 +1,109 @@
+package com.gu.supportermetricsjob
+
+import java.sql.{ Connection, DriverManager }
+
+import com.amazonaws.auth.{ AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain }
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
+import com.gu.supportermetricsjob.Churn.{ ChurnRequest, ChurnResults }
+import org.joda.time._
+
+import scala.util.{ Failure, Success, Try }
+
+object SendChurnEmailsJob extends Logging {
+
+  case class Config(app: String, stack: String, stage: String, emailTo: String, emailFrom: String, prestoUrl: String, emailLine: String)
+
+  implicit val credentials: AWSCredentialsProviderChain = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("membership"),
+    DefaultAWSCredentialsProviderChain.getInstance())
+
+  implicit val ses: AmazonSimpleEmailService = Emailer.makeSes()
+
+  def createConn(prestoUrl: String) = Try {
+    Class.forName("com.facebook.presto.jdbc.PrestoDriver")
+    DriverManager.getConnection(prestoUrl, "user", "***empty***")
+  }
+
+  def run(config: Config): String = {
+
+    val result = for {
+      conn <- createConn(config.prestoUrl)
+      dateToRun = LocalDate.now().minusDays(1)
+      request = ChurnRequest(dateToRun, dateToRun, Weeks.ONE, "Supporter")
+      count <- PrestoQuery.churnQueries(request)(conn)
+      _ = logger.info(s"count: $count")
+      emailLines = buildEmailBody(config.emailLine, request, count)
+      email = Emailer.Email("Automated Daily Churn Email", emailLines, config.emailFrom, config.emailTo)
+      emailResult <- Emailer.sendEmail(email)
+    } yield emailResult
+
+    result match {
+      case Failure(e) =>
+        logger.error("failed to send email", e)
+        "failed to send email"
+      case Success(message) => s"successfully emailed: $message"
+    }
+  }
+
+  def buildEmailBody(emailLine: String, request: ChurnRequest, count: ChurnResults): String = {
+    Seq(
+      "<h2>What is this email?</h2>",
+      "This email is to evidence agreement of Churn metric in support of KR3.  It shows a minimum viable product for visibility, but should be extended " +
+        "to support other use cases in the form of more emails, a dashboard, or anything else.",
+      "The full churn spreadsheet is in Matt's posession, this email is intended as a summary for wider digestability, and to improve confidence that everyone really is using the same definition. " +
+        "It comes from the data lake.",
+      "If you have any requirements/improvements/disagreements then please come back on this so we can make this useful.  If no-one finds it useful, then it won't last beyond the end of the quarter!",
+
+      "<h2>What is 'Churn'?</h2>",
+      "Churn is the percentage of total customers who stop using your service during a period.",
+      "",
+      "<strong>Churn / Average Base</strong>",
+      "",
+      s"$emailLine",
+
+      "<h2>The figures!</h2>",
+      s"${request.pretty}",
+      "",
+      s"${count.breakdown.mkString("<br>\n")}",
+      "",
+      s"<strong>${count.result}</strong>",
+
+      "<h2>Questions/suggestions?</h2>",
+      "Let us know of course, and we will improve this."
+    ).mkString("<br>\n")
+  }
+}
+
+object Churn {
+
+  case class ChurnRequest(statusDate: LocalDate, endDate: LocalDate, period: ReadablePeriod, product: String) {
+
+    val periodString: String = period match {
+      case Months.ONE => "one month"
+      case x => x.toString
+    }
+
+    val pretty: String = s"product $product for $periodString before $endDate"
+
+  }
+
+  case class ChurnResults(baseStart: Int, baseEnd: Int, churnCount: Int, periodsInYear: Double) {
+
+    val subscriptionChurnRate: Double =
+      churnCount / ((baseStart + baseEnd) / 2.0)
+
+    val annualChurnRate: Double =
+      subscriptionChurnRate * periodsInYear
+
+    val breakdown: Seq[String] = Seq(
+      s"base at start: $baseStart",
+      s"base at end: $baseEnd",
+      s"churner count: $churnCount")
+
+    val result =
+      s"annualised churn rate = ${Math.round(annualChurnRate * 1000).toDouble / 10}%"
+
+  }
+
+}

--- a/src/main/scala/com/gu/supportermetricsjob/TestIt.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/TestIt.scala
@@ -17,8 +17,8 @@ object TestIt extends Logging {
     }
     logger.info(s"config: $config")
     println(SendChurnEmailsJob.run(Config(
-      app = "dev",
-      stack = "dev",
+      app = "supporter-metrics-job",
+      stack = "memb-supporter-metrics-job",
       stage = "dev",
       emailTo = config.getProperty("email.to"),
       emailFrom = config.getProperty("email.from"),

--- a/src/main/scala/com/gu/supportermetricsjob/TestIt.scala
+++ b/src/main/scala/com/gu/supportermetricsjob/TestIt.scala
@@ -1,0 +1,29 @@
+package com.gu.supportermetricsjob
+
+import java.io.FileInputStream
+import java.util.Properties
+
+import com.gu.supportermetricsjob.SendChurnEmailsJob.Config
+
+object TestIt extends Logging {
+  def main(args: Array[String]): Unit = {
+    logger.info("running in test mode")
+    val config = new Properties()
+    val configStream = new FileInputStream("/etc/gu/supporter-metrics-job.properties")
+    try {
+      config.load(configStream)
+    } finally {
+      configStream.close
+    }
+    logger.info(s"config: $config")
+    println(SendChurnEmailsJob.run(Config(
+      app = "dev",
+      stack = "dev",
+      stage = "dev",
+      emailTo = config.getProperty("email.to"),
+      emailFrom = config.getProperty("email.from"),
+      prestoUrl = config.getProperty("presto.url"),
+      emailLine = config.getProperty("email.line"))))
+
+  }
+}


### PR DESCRIPTION
So at present we have a KR stating to "_Have renewal, payment failure and supporter satisfaction metrics which we (the Guardian) can measure and agree on_"

Apparently this is doing well, but to gain trust that we are getting value from this, we need visibility amongst the KR team (and onwards to those who will use it).

As such I have implemented a minimum viable product to demonstrate this, which should produce a headline figure every day for supporter churn.  If that is happening and everyone is agreeing (and ideally wanting improvements/adding new people) then I would have good confidence that the metric is useful.  In that case we should be giving a high confidence of meeting that part of the OKR.

Initially this email should go out early in the morning, but based on feedback this will probably change.

Example email:

![image](https://user-images.githubusercontent.com/7304387/29673322-c5bf45e6-88e6-11e7-9a7a-cc6729839ad0.png)

@pvighi @paulbrown1982 @lmath @AWare @jacobwinch 